### PR TITLE
[sfp] Ignore processing ports that are not front-panel

### DIFF
--- a/sonic_platform_base/sonic_sfp/sfputilhelper.py
+++ b/sonic_platform_base/sonic_sfp/sfputilhelper.py
@@ -14,7 +14,6 @@ try:
     from natsort import natsorted
     from portconfig import get_port_config
     from sonic_py_common import device_info, multi_asic
-    from sonic_py_common.interface import backplane_prefix, inband_prefix, recirc_prefix
 
 except ImportError as e:
     raise ImportError("%s - required module not found" % str(e))
@@ -66,13 +65,11 @@ class SfpUtilHelper(object):
                 print('Failed to get port config', file=sys.stderr)
                 sys.exit(1)
 
-        logical_list = []
         for intf in ports.keys():
-             logical_list.append(intf)
+            # Ignore if this is a non front panel interface
+            if multi_asic.is_front_panel_port(intf, ports[intf].get(multi_asic.PORT_ROLE, None)):
+                logical.append(intf)
 
-        # Ignore if this is an internal backplane interface and Inband interface
-        logical = [name for name in logical_list
-                      if not name.startswith((backplane_prefix(), inband_prefix(), recirc_prefix()))]
         logical = natsorted(logical, key=lambda y: y.lower())
         logical_to_physical, physical_to_logical = OrderedDict(),  OrderedDict()
 

--- a/tests/platform_json/hwsku_role.json
+++ b/tests/platform_json/hwsku_role.json
@@ -1,0 +1,46 @@
+{
+    "interfaces": {
+        "Ethernet0": {
+            "default_brkout_mode": "1x200G[100G,50G,40G,25G,10G,1G]"
+        },
+        "Ethernet4": {
+            "default_brkout_mode": "1x200G[100G,50G,40G,25G,10G,1G]"
+        },
+        "Ethernet8": {
+            "default_brkout_mode": "1x200G[100G,50G,40G,25G,10G,1G]"
+        },
+        "Ethernet12": {
+            "default_brkout_mode": "1x200G[100G,50G,40G,25G,10G,1G]"
+        },
+        "Ethernet16": {
+            "default_brkout_mode": "1x200G[100G,50G,40G,25G,10G,1G]"
+        },
+        "Ethernet20": {
+            "default_brkout_mode": "1x200G[100G,50G,40G,25G,10G,1G]"
+        },
+        "Ethernet24": {
+            "default_brkout_mode": "1x200G[100G,50G,40G,25G,10G,1G]"
+        },
+        "Ethernet28": {
+            "default_brkout_mode": "1x200G[100G,50G,40G,25G,10G,1G]"
+        },
+        "Ethernet32": {
+            "default_brkout_mode": "1x200G[100G,50G,40G,25G,10G,1G]"
+        },
+        "Ethernet36": {
+            "default_brkout_mode": "1x200G[100G,50G,40G,25G,10G,1G]"
+        },
+        "Ethernet40": {
+            "default_brkout_mode": "1x200G[100G,50G,40G,25G,10G,1G]",
+            "role": "Ext"
+        },
+        "Ethernet44": {
+            "default_brkout_mode": "1x200G[100G,50G,40G,25G,10G,1G]",
+            "role": "Int"
+        },
+        "Ethernet48": {
+            "default_brkout_mode": "1x200G[100G,50G,40G,25G,10G,1G]",
+            "role": "Dpc"
+        }
+    }
+}

--- a/tests/sfputilhelper_test.py
+++ b/tests/sfputilhelper_test.py
@@ -22,6 +22,20 @@ PORT_LIST = [
     "Ethernet48"
 ]
 
+PORT_FILTERED_LIST = [
+    "Ethernet0",
+    "Ethernet4",
+    "Ethernet8",
+    "Ethernet12",
+    "Ethernet16",
+    "Ethernet20",
+    "Ethernet24",
+    "Ethernet28",
+    "Ethernet32",
+    "Ethernet36",
+    "Ethernet40",
+]
+
 LOGICAL_TO_PHYSICAL ={
     'Ethernet0': [1],
     'Ethernet4': [2],
@@ -56,6 +70,7 @@ PHYSICAL_TO_LOGICAL = {
 
 test_dir = os.path.dirname(os.path.realpath(__file__))
 hwsku_json_file = os.path.join(test_dir, 'platform_json', 'hwsku.json')
+hwsku_role_json_file = os.path.join(test_dir, 'platform_json', 'hwsku_role.json')
 
 @pytest.fixture(scope="class")
 def setup_class(request):
@@ -118,3 +133,14 @@ class TestSfpUtilHelper(object):
 
         assert sfputil_helper.logical_to_physical == LOGICAL_TO_PHYSICAL
         assert sfputil_helper.physical_to_logical == PHYSICAL_TO_LOGICAL
+
+    @mock.patch('portconfig.get_hwsku_file_name', mock.MagicMock(return_value=hwsku_role_json_file))
+    def test_read_all_port_mappings_role(self):
+        sfputil_helper = sfputilhelper.SfpUtilHelper()
+        sfputil_helper.logical = []
+        sfputil_helper.logical_to_physical = {}
+        sfputil_helper.physical_to_logical = {}
+        sfputil_helper.read_all_porttab_mappings(self.platform_json_dir, 2)
+        logical_port_list = sfputil_helper.logical
+
+        assert len(logical_port_list) == len(PORT_FILTERED_LIST)


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

#### Description
<!--
     Describe your changes in detail
-->

Ignore processing the front panel ports in base sfp classes. This include ports with suffixes other than Ethernet and ports that have role field set to any value other than Ext.

#### Motivation and Context
<!--
     Why is this change required? What problem does it solve?
     If this pull request closes/resolves an open Issue, make sure you
     include the text "fixes #xxxx", "closes #xxxx" or "resolves #xxxx" here
-->

#### How Has This Been Tested?
<!--
     Please describe in detail how you tested your changes.
     Include details of your testing environment, and the tests you ran to
     see how your change affects other areas of the code, etc.
-->

#### Additional Information (Optional)

